### PR TITLE
7 add rundeck compatible versions endpoint

### DIFF
--- a/oc_distributives_mongo_api/wsgi.py
+++ b/oc_distributives_mongo_api/wsgi.py
@@ -7,7 +7,7 @@ from .config import Config
 
 _settings = dict()
 
-for _s in ["url", "user", "password", "name", "connect_attempts"]:
+for _s in ["url", "user", "password", "db", "connect_attempts"]:
     _env = "_".join(["mongo", _s]).upper()
     _v = os.getenv(_env)
 
@@ -20,7 +20,7 @@ _i = 0
 while True:
     try:
         connect(
-                _settings["name"],
+                _settings["db"],
                 host=_settings["url"],
                 username=_settings["user"],
                 password=_settings["password"],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 if "test" in sys.argv:
     raise NotImplementedError("'python setup.py test' is buggy, please run as 'python -m unittest'")
 
-__version = "2.2.1"
+__version = "2.2.2"
 
 setup(name="oc-distributives-mongo-api",
       version=__version,


### PR DESCRIPTION
Closes #7 
- Added */rundeck/versions_by_citype* endpoint for Rundeck drop-down lists:
-- sorted versions
-- added empty choice option
-- possibility to filter by *artifact_deliverable* value recursively
- unit-test added for new endpoint
- additionaly log unexpected exceptions stacktrace
-  version increased